### PR TITLE
fix

### DIFF
--- a/src/app/admin/components/layout/AdminLayout/sidebar/index.tsx
+++ b/src/app/admin/components/layout/AdminLayout/sidebar/index.tsx
@@ -3,7 +3,7 @@
 import { cn } from "@/lib/utils";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Camera, Calendar, Users } from "lucide-react";
+import { Camera, Calendar, Users, Package, BarChart3, Settings, LayoutDashboard } from "lucide-react";
 import { ArrowLeftIcon } from "./icons";
 import { useSidebarContext } from "./sidebar-context";
 
@@ -12,9 +12,13 @@ export function Sidebar() {
   const { setIsOpen, isOpen, isMobile, toggleSidebar } = useSidebarContext();
 
   const navItems = [
+    { href: "/admin/dashboard", label: "Dashboard", icon: LayoutDashboard },
     { href: "/admin/studios", label: "Studios", icon: Camera },
     { href: "/admin/bookings", label: "Bookings", icon: Calendar },
+    { href: "/admin/staff", label: "Thiết bị", icon: Package },
     { href: "/admin/users", label: "Người dùng", icon: Users },
+    { href: "/admin/reports", label: "Thống kê", icon: BarChart3 },
+    { href: "/admin/settings", label: "Cài đặt", icon: Settings },
   ];
 
   return (


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Extend admin sidebar with links for Dashboard, Thiết bị (Staff), Thống kê (Reports), and Cài đặt (Settings) and import corresponding icons.
> 
> - **Admin UI**
>   - **Sidebar (`src/app/admin/components/layout/AdminLayout/sidebar/index.tsx`)**:
>     - Add nav items: `Dashboard` (`/admin/dashboard`), `Thiết bị` (`/admin/staff`), `Thống kê` (`/admin/reports`), `Cài đặt` (`/admin/settings`).
>     - Import and use icons: `LayoutDashboard`, `Package`, `BarChart3`, `Settings` (alongside existing `Camera`, `Calendar`, `Users`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a4b4617132558eed1354c702fa44ac215a23ab6b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->